### PR TITLE
Upload fastas

### DIFF
--- a/src/app/backend.py
+++ b/src/app/backend.py
@@ -389,8 +389,8 @@ def fastapi_app():
             # ... add remaining validation here
 
         validate_run_metadata(run_metadata)
-
         write_run_metadata_to_volume(run_id, run_metadata)
+        save_fasta_to_volume(file_content, original_filename, run_id)
 
         logger.info(
             f"Submitted run {run_id}. {run_metadata['cached_sequences']}/{run_metadata['total_sequences']} sequences are cached"

--- a/src/app/backend.py
+++ b/src/app/backend.py
@@ -180,7 +180,7 @@ def fastapi_app():
         SequenceData
     )
 
-    from fastapi_utils.utils import read_sequences_from_filename, create_sequences_data, get_completed_zip_paths, merge_zip_archives
+    from fastapi_utils.utils import read_sequences_from_filename, create_sequences_data, get_completed_zip_paths, merge_zip_archives, replace_idr_ranges
 
     """Lightweight FastAPI application for handling uploads and job management."""
     api = FastAPI(title="Nardini Backend", version="1.0.0")
@@ -232,6 +232,7 @@ def fastapi_app():
 
             # Parse sequences using the reference code with a temporary file
             file_content = content.decode("utf-8")
+            file_content = replace_idr_ranges(file_content)
 
             # Create temporary file to use with read_sequences_from_filename
             with tempfile.NamedTemporaryFile(

--- a/src/fastapi_utils/utils.py
+++ b/src/fastapi_utils/utils.py
@@ -1,5 +1,3 @@
-# ONLY include: read_sequences_from_filename, create_sequences_data, get_completed_zip_paths, merge_zip_archives
-
 import json
 import logging
 import os
@@ -10,7 +8,8 @@ from typing import Any, Dict, List
 from uuid import uuid4
 
 from shared_utils.schemas import SequencesMapping, SequenceData
-from shared_utils.file_utils import get_zip_by_idr_dir, get_zip_by_fasta_dir, get_runs_dir, get_run_metadata
+from shared_utils.file_utils import clean_filename, get_zip_by_idr_dir, get_zip_by_fasta_dir, get_runs_dir, get_run_metadata, save_fasta_to_volume
+import re
 
 logger = logging.getLogger(__name__)
 
@@ -89,7 +88,6 @@ def get_completed_zip_paths(
 # ------------------------------------------------------------------------------- #
 
 
-# The following functions are copied from nardini.utils.py
 # NOTE: See https://github.com/mshinn23/nardini/blob/main/nardini/utils.py
 def read_sequences_from_filename(sequence_filename, default_name, verbose=False):
     """This is a helper function to read in sequences from a sequence FASTA file.
@@ -347,4 +345,9 @@ def sanitize_output_filename(filename: str) -> str:
         filename = filename[:-suffix_len]
     if not filename.endswith(".zip"):
         filename = filename + ".zip"
-    return filename
+    return clean_filename(filename)
+
+def replace_idr_ranges(content: str) -> str:
+    """Replace IDR range format from '[n, m]' to '[n-m]' in FASTA headers."""
+    formatted_content = re.sub(r'\[(\d+),\s*(\d+)\]', r'[\1-\2]', content)
+    return formatted_content

--- a/src/shared_utils/file_utils.py
+++ b/src/shared_utils/file_utils.py
@@ -4,6 +4,10 @@ from pathlib import Path
 
 from shared_utils.schemas import RunData
 
+def clean_filename(filename: str) -> str:
+    """Sanitize a filename to prevent path traversal."""
+    return Path(filename).name
+
 def get_volume_dir() -> Path:
     return Path("/data")
 
@@ -21,9 +25,13 @@ def get_zip_by_fasta_dir() -> Path:
     """Absolute path to merged zip outputs, keyed by `run_id`."""
     return get_volume_dir() / "zipfiles" / "by_fasta"
 
+def get_fasta_dir() -> Path:
+    """Absolute path to per-sequence zip outputs, keyed by `seq_uuid`."""
+    return get_volume_dir() / "fasta_inputs"
+
 
 def get_run_json_path(run_id: str) -> Path:
-    return get_runs_dir() / f"{run_id}.json"
+    return get_runs_dir() / f"{clean_filename(run_id)}.json"
 
 
 def read_json(path: Path) -> dict:
@@ -48,9 +56,18 @@ def write_run_metadata_to_volume(run_id: str, data: RunData) -> None:
 def ensure_volume_directories() -> bool:
     """Ensure the required directories exist in the mounted volume."""
     was_created = False
-    for directory in [get_zip_by_fasta_dir(), get_zip_by_idr_dir(), get_runs_dir()]:
+    for directory in [get_zip_by_fasta_dir(), get_zip_by_idr_dir(), get_runs_dir(), get_fasta_dir()]:
         if not directory.exists():
             logging.warning(f"Volume directory {directory} does not exist, creating it")
             directory.mkdir(parents=True, exist_ok=True)
             was_created = True
     return was_created
+
+
+def save_fasta_to_volume(content: str, filename: str, run_id: str) -> None:
+    path = get_fasta_dir() / clean_filename(run_id) / clean_filename(filename)
+    if not path.parent.exists():
+        logging.info(f"Saving fasta to folder {path.parent}")
+        path.parent.mkdir(parents=True, exist_ok=True)
+    with open(path, "w") as f:
+        f.write(content)

--- a/src/shared_utils/file_utils.py
+++ b/src/shared_utils/file_utils.py
@@ -1,5 +1,5 @@
-import logging
 import json
+import logging
 from pathlib import Path
 
 from shared_utils.schemas import RunData
@@ -53,6 +53,14 @@ def write_run_metadata_to_volume(run_id: str, data: RunData) -> None:
     path = get_run_json_path(run_id)
     write_json(path, data)
 
+def save_fasta_to_volume(content: str, filename: str, run_id: str) -> None:
+    path = get_fasta_dir() / clean_filename(run_id) / clean_filename(filename)
+    if not path.parent.exists():
+        logging.info(f"Saving fasta to folder {path.parent}")
+        path.parent.mkdir(parents=True, exist_ok=True)
+    with open(path, "w") as f:
+        f.write(content)
+
 def ensure_volume_directories() -> bool:
     """Ensure the required directories exist in the mounted volume."""
     was_created = False
@@ -64,10 +72,3 @@ def ensure_volume_directories() -> bool:
     return was_created
 
 
-def save_fasta_to_volume(content: str, filename: str, run_id: str) -> None:
-    path = get_fasta_dir() / clean_filename(run_id) / clean_filename(filename)
-    if not path.parent.exists():
-        logging.info(f"Saving fasta to folder {path.parent}")
-        path.parent.mkdir(parents=True, exist_ok=True)
-    with open(path, "w") as f:
-        f.write(content)


### PR DESCRIPTION
- On a successful upload, create a folder associating run-id to the fasta file. This allows fastas to be viewed or downloaded later.